### PR TITLE
Add fork notes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2020 Guy Peled guypeled76@gmail.com
+Copyright (c) 2025 BaseMachina, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+**This is forked from [go-gorm/bigquery](https://github.com/go-gorm/bigquery).**
+
+The following are the main changes that have been made:
+
+## Changes
+
+_To be written._
+
 #  BigQuery SQL Driver & GORM Dialect for Golang
 This is an implementation of the BigQuery Client as a database/sql/driver for easy integration and usage.
 


### PR DESCRIPTION
Update the README and LICENSE to reflect that this repository was forked from [go-gorm/bigquery](https://github.com/go-gorm/bigquery).