### PR TITLE
implement ColumnTypeDatabaseTypeName

### DIFF
--- a/driver/columns.go
+++ b/driver/columns.go
@@ -11,11 +11,13 @@ import (
 type bigQuerySchema interface {
 	ColumnNames() []string
 	ConvertColumnValue(index int, value bigquery.Value) (driver.Value, error)
+	ColumnTypes() []string
 }
 
 type bigQueryColumns struct {
 	names   []string
 	columns []bigQueryColumn
+	types   []string
 }
 
 func (columns bigQueryColumns) ConvertColumnValue(index int, value bigquery.Value) (driver.Value, error) {
@@ -29,6 +31,10 @@ func (columns bigQueryColumns) ConvertColumnValue(index int, value bigquery.Valu
 
 func (columns bigQueryColumns) ColumnNames() []string {
 	return columns.names
+}
+
+func (columns bigQueryColumns) ColumnTypes() []string {
+	return columns.types
 }
 
 type bigQueryReroutedColumn struct {
@@ -74,6 +80,7 @@ func (column bigQueryColumn) ConvertValue(value bigquery.Value) (driver.Value, e
 func createBigQuerySchema(schema bigquery.Schema, schemaAdaptor adaptor.SchemaAdaptor) bigQuerySchema {
 	var names []string
 	var columns []bigQueryColumn
+	var types []string
 	for _, column := range schema {
 
 		name := column.Name
@@ -89,9 +96,11 @@ func createBigQuerySchema(schema bigquery.Schema, schemaAdaptor adaptor.SchemaAd
 			Schema:  column.Schema,
 			Adaptor: columnAdaptor,
 		})
+		types = append(types, string(column.Type))
 	}
 	return &bigQueryColumns{
 		names,
 		columns,
+		types,
 	}
 }

--- a/driver/rows.go
+++ b/driver/rows.go
@@ -13,6 +13,8 @@ type bigQueryRows struct {
 	adaptor adaptor.SchemaAdaptor
 }
 
+var _ driver.RowsColumnTypeDatabaseTypeName = &bigQueryRows{}
+
 func (rows *bigQueryRows) ensureSchema() {
 	if rows.schema == nil {
 		rows.schema = rows.source.GetSchema()
@@ -52,4 +54,12 @@ func (rows *bigQueryRows) Next(dest []driver.Value) error {
 	}
 
 	return nil
+}
+
+func (rows *bigQueryRows) ColumnTypeDatabaseTypeName(index int) string {
+	types := rows.schema.ColumnTypes()
+	if index >= len(types) {
+		return "ERR_OUT_OF_RANGE"
+	}
+	return types[index]
 }


### PR DESCRIPTION
This pull request adds the `ColumnTypeDatabaseTypeName` method to the `bigQueryRows` type. 

This type already implements the [`sql/driver.Rows`](https://pkg.go.dev/database/sql/driver#Rows) interface. With this change, `bigQueryRows` also implements the [`sql/driver.RowsColumnTypeDatabaseTypeName`](https://pkg.go.dev/database/sql/driver#RowsColumnTypeDatabaseTypeName) interface, allowing users to retrieve the database-specific type names of columns.