### PR TITLE
Update module name to basemachina/go-bigquery

### DIFF
--- a/adaptor.go
+++ b/adaptor.go
@@ -2,10 +2,11 @@ package bigquery
 
 import (
 	"database/sql/driver"
+	"reflect"
+
 	"gorm.io/driver/bigquery/adaptor"
 	"gorm.io/gorm"
 	"gorm.io/gorm/schema"
-	"reflect"
 )
 
 type bigQuerySchemaAdaptor struct {

--- a/adaptor.go
+++ b/adaptor.go
@@ -4,7 +4,7 @@ import (
 	"database/sql/driver"
 	"reflect"
 
-	"gorm.io/driver/bigquery/adaptor"
+	"github.com/basemachina/go-bigquery/adaptor"
 	"gorm.io/gorm"
 	"gorm.io/gorm/schema"
 )

--- a/bigquery.go
+++ b/bigquery.go
@@ -3,6 +3,10 @@ package bigquery
 import (
 	"database/sql"
 	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+
 	"gorm.io/driver/bigquery/adaptor"
 	_ "gorm.io/driver/bigquery/driver"
 	"gorm.io/gorm"
@@ -10,9 +14,6 @@ import (
 	"gorm.io/gorm/logger"
 	"gorm.io/gorm/migrator"
 	"gorm.io/gorm/schema"
-	"reflect"
-	"regexp"
-	"strings"
 )
 
 type Dialector struct {

--- a/bigquery.go
+++ b/bigquery.go
@@ -7,8 +7,8 @@ import (
 	"regexp"
 	"strings"
 
-	"gorm.io/driver/bigquery/adaptor"
-	_ "gorm.io/driver/bigquery/driver"
+	"github.com/basemachina/go-bigquery/adaptor"
+	_ "github.com/basemachina/go-bigquery/driver"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"gorm.io/gorm/logger"

--- a/builders.go
+++ b/builders.go
@@ -3,9 +3,10 @@ package bigquery
 import (
 	"database/sql"
 	"database/sql/driver"
+	"reflect"
+
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
-	"reflect"
 )
 
 func initializeBuilders(db *gorm.DB) {

--- a/callbacks.go
+++ b/callbacks.go
@@ -1,7 +1,7 @@
 package bigquery
 
 import (
-	"gorm.io/driver/bigquery/adaptor"
+	"github.com/basemachina/go-bigquery/adaptor"
 	"gorm.io/gorm"
 	"gorm.io/gorm/callbacks"
 )

--- a/driver/columns.go
+++ b/driver/columns.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 
 	"cloud.google.com/go/bigquery"
-	"gorm.io/driver/bigquery/adaptor"
+	"github.com/basemachina/go-bigquery/adaptor"
 )
 
 type bigQuerySchema interface {

--- a/driver/connection.go
+++ b/driver/connection.go
@@ -1,10 +1,11 @@
 package driver
 
 import (
-	"cloud.google.com/go/bigquery"
 	"context"
 	"database/sql/driver"
 	"fmt"
+
+	"cloud.google.com/go/bigquery"
 )
 
 type bigQueryConnection struct {

--- a/driver/result.go
+++ b/driver/result.go
@@ -1,8 +1,9 @@
 package driver
 
 import (
-	"cloud.google.com/go/bigquery"
 	"errors"
+
+	"cloud.google.com/go/bigquery"
 )
 
 type bigQueryResult struct {

--- a/driver/rows.go
+++ b/driver/rows.go
@@ -4,8 +4,8 @@ import (
 	"database/sql/driver"
 	"io"
 
+	"github.com/basemachina/go-bigquery/adaptor"
 	"google.golang.org/api/iterator"
-	"gorm.io/driver/bigquery/adaptor"
 )
 
 type bigQueryRows struct {

--- a/driver/source.go
+++ b/driver/source.go
@@ -1,10 +1,11 @@
 package driver
 
 import (
-	"cloud.google.com/go/bigquery"
 	"errors"
-	"gorm.io/driver/bigquery/adaptor"
 	"io"
+
+	"cloud.google.com/go/bigquery"
+	"gorm.io/driver/bigquery/adaptor"
 )
 
 type bigQuerySource interface {
@@ -15,8 +16,8 @@ type bigQuerySource interface {
 type bigQueryRowIteratorSource struct {
 	iterator      *bigquery.RowIterator
 	schemaAdaptor adaptor.SchemaAdaptor
-	prevValues []bigquery.Value
-	prevError error
+	prevValues    []bigquery.Value
+	prevError     error
 }
 
 func (source *bigQueryRowIteratorSource) GetSchema() bigQuerySchema {

--- a/driver/source.go
+++ b/driver/source.go
@@ -5,7 +5,7 @@ import (
 	"io"
 
 	"cloud.google.com/go/bigquery"
-	"gorm.io/driver/bigquery/adaptor"
+	"github.com/basemachina/go-bigquery/adaptor"
 )
 
 type bigQuerySource interface {

--- a/driver/statement.go
+++ b/driver/statement.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 
 	"cloud.google.com/go/bigquery"
+	"github.com/basemachina/go-bigquery/adaptor"
 	"github.com/sirupsen/logrus"
-	"gorm.io/driver/bigquery/adaptor"
 )
 
 type bigQueryStatement struct {

--- a/driver/statement.go
+++ b/driver/statement.go
@@ -1,10 +1,11 @@
 package driver
 
 import (
-	"cloud.google.com/go/bigquery"
 	"context"
 	"database/sql/driver"
 	"errors"
+
+	"cloud.google.com/go/bigquery"
 	"github.com/sirupsen/logrus"
 	"gorm.io/driver/bigquery/adaptor"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gorm.io/driver/bigquery
+module github.com/basemachina/go-bigquery
 
 go 1.20
 

--- a/migrator.go
+++ b/migrator.go
@@ -2,6 +2,7 @@ package bigquery
 
 import (
 	"errors"
+
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"gorm.io/gorm/migrator"


### PR DESCRIPTION
Updated the module name to `basemachina/go-bigquery`. Additionally, import statements were formatted using the `goimports` command.