### PR TITLE
fix: return -1 from NumInput() to enable placeholder parameter queries

### DIFF
--- a/driver/statement.go
+++ b/driver/statement.go
@@ -20,7 +20,7 @@ func (statement bigQueryStatement) Close() error {
 }
 
 func (statement bigQueryStatement) NumInput() int {
-	return 0
+	return -1
 }
 
 func (bigQueryStatement) CheckNamedValue(*driver.NamedValue) error {


### PR DESCRIPTION
The NumInput() method is required by the [sql.driver.Stmt](https://pkg.go.dev/database/sql/driver#Stmt) interface. 

Previously returning 0 prevented queries with placeholder parameters from executing. Returning -1 allows the sql package to skip parameter count validation, enabling proper query execution with placeholders.