### PR TITLE
implement driver.RowsColumnTypeNullable interface

### DIFF
--- a/driver/columns.go
+++ b/driver/columns.go
@@ -12,12 +12,14 @@ type bigQuerySchema interface {
 	ColumnNames() []string
 	ConvertColumnValue(index int, value bigquery.Value) (driver.Value, error)
 	columnTypes() []bigquery.FieldType
+	RequiredFlags() []bool
 }
 
 type bigQueryColumns struct {
-	names   []string
-	columns []bigQueryColumn
-	types   []bigquery.FieldType
+	names         []string
+	columns       []bigQueryColumn
+	types         []bigquery.FieldType
+	requiredFlags []bool
 }
 
 func (columns bigQueryColumns) ConvertColumnValue(index int, value bigquery.Value) (driver.Value, error) {
@@ -35,6 +37,10 @@ func (columns bigQueryColumns) ColumnNames() []string {
 
 func (columns bigQueryColumns) columnTypes() []bigquery.FieldType {
 	return columns.types
+}
+
+func (columns bigQueryColumns) RequiredFlags() []bool {
+	return columns.requiredFlags
 }
 
 type bigQueryReroutedColumn struct {
@@ -81,6 +87,7 @@ func createBigQuerySchema(schema bigquery.Schema, schemaAdaptor adaptor.SchemaAd
 	var names []string
 	var columns []bigQueryColumn
 	var types []bigquery.FieldType
+	var requiredFlags []bool
 	for _, column := range schema {
 
 		name := column.Name
@@ -97,10 +104,12 @@ func createBigQuerySchema(schema bigquery.Schema, schemaAdaptor adaptor.SchemaAd
 			Adaptor: columnAdaptor,
 		})
 		types = append(types, column.Type)
+		requiredFlags = append(requiredFlags, column.Required)
 	}
 	return &bigQueryColumns{
 		names,
 		columns,
 		types,
+		requiredFlags,
 	}
 }

--- a/driver/rows.go
+++ b/driver/rows.go
@@ -92,3 +92,10 @@ func (rows *bigQueryRows) ColumnTypeDatabaseTypeName(index int) string {
 	types := rows.schema.columnTypes()
 	return string(types[index])
 }
+
+var _ driver.RowsColumnTypeNullable = (*bigQueryRows)(nil)
+
+func (rows *bigQueryRows) ColumnTypeNullable(index int) (bool, bool) {
+	requiredFlags := rows.schema.RequiredFlags()
+	return !requiredFlags[index], true
+}

--- a/driver/rows_test.go
+++ b/driver/rows_test.go
@@ -64,3 +64,42 @@ func TestConvertBaseMachinaUnsupportedValueToString(t *testing.T) {
 		})
 	}
 }
+
+func TestBigQueryRowsColumnTypeNullable(t *testing.T) {
+	t.Parallel()
+
+	rows := &bigQueryRows{
+		schema: createBigQuerySchema(bigquery.Schema{
+			{Name: "id", Type: bigquery.IntegerFieldType, Required: true},
+			{Name: "name", Type: bigquery.StringFieldType, Required: false},
+		}, nil),
+	}
+
+	tests := map[string]struct {
+		index        int
+		wantNullable bool
+	}{
+		"id column is not nullable": {
+			index:        0,
+			wantNullable: false,
+		},
+		"name column is nullable": {
+			index:        1,
+			wantNullable: true,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			nullable, ok := rows.ColumnTypeNullable(tt.index)
+			if nullable != tt.wantNullable {
+				t.Errorf("ColumnTypeNullable() nullable = %v, want %v", nullable, tt.wantNullable)
+			}
+			if !ok {
+				t.Errorf("ColumnTypeNullable() ok = %v, want true", ok)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request implements [database/sql/driver.RowsColumnTypeNullable](https://pkg.go.dev/database/sql/driver#RowsColumnTypeNullable) to `*bigQueryRows`.

This allows database/sql to determine column nullability from the `Required` flag in the BigQuery schema.