### PR TITLE
handle array type representation in ColumnTypeDatabaseTypeName

### DIFF
--- a/driver/column_type_test.go
+++ b/driver/column_type_test.go
@@ -27,7 +27,7 @@ func TestColumnTypeDatabaseTypeName(t *testing.T) {
 		0: "STRING",
 		1: "NUMERIC",
 		2: "BOOLEAN",
-		3: "ARRAY",
+		3: "[]STRING",
 	}
 
 	for index, want := range testCases {

--- a/driver/column_type_test.go
+++ b/driver/column_type_test.go
@@ -1,6 +1,7 @@
 package driver
 
 import (
+	"fmt"
 	"testing"
 
 	"cloud.google.com/go/bigquery"
@@ -8,20 +9,32 @@ import (
 )
 
 func TestColumnTypeDatabaseTypeName(t *testing.T) {
+	t.Parallel()
+
 	rows := &bigQueryRows{
-		schema: bigQueryColumns{
-			types: []bigquery.FieldType{
-				bigquery.StringFieldType,
-				bigquery.NumericFieldType,
+		schema: createBigQuerySchema(
+			bigquery.Schema{
+				{Name: "string", Type: bigquery.StringFieldType, Repeated: false},
+				{Name: "numeric", Type: bigquery.NumericFieldType, Repeated: false},
+				{Name: "boolean", Type: bigquery.BooleanFieldType, Repeated: false},
+				{Name: "array_of_string", Type: bigquery.StringFieldType, Repeated: true},
 			},
-		},
+			nil,
+		),
 	}
 
 	testCases := map[int]string{
 		0: "STRING",
 		1: "NUMERIC",
+		2: "BOOLEAN",
+		3: "ARRAY",
 	}
-	for index, expected := range testCases {
-		assert.Equal(t, expected, rows.ColumnTypeDatabaseTypeName(index))
+
+	for index, want := range testCases {
+		t.Run(fmt.Sprintf("column %d: %s", index, want), func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, want, rows.ColumnTypeDatabaseTypeName(index))
+		})
 	}
 }

--- a/driver/columns.go
+++ b/driver/columns.go
@@ -103,7 +103,11 @@ func createBigQuerySchema(schema bigquery.Schema, schemaAdaptor adaptor.SchemaAd
 			Schema:  column.Schema,
 			Adaptor: columnAdaptor,
 		})
-		types = append(types, column.Type)
+		if column.Repeated {
+			types = append(types, "ARRAY")
+		} else {
+			types = append(types, column.Type)
+		}
 		requiredFlags = append(requiredFlags, column.Required)
 	}
 	return &bigQueryColumns{

--- a/driver/columns.go
+++ b/driver/columns.go
@@ -11,14 +11,14 @@ import (
 type bigQuerySchema interface {
 	ColumnNames() []string
 	ConvertColumnValue(index int, value bigquery.Value) (driver.Value, error)
-	columnTypes() []bigquery.FieldType
+	columnTypes() []string
 	RequiredFlags() []bool
 }
 
 type bigQueryColumns struct {
 	names         []string
 	columns       []bigQueryColumn
-	types         []bigquery.FieldType
+	types         []string
 	requiredFlags []bool
 }
 
@@ -35,7 +35,7 @@ func (columns bigQueryColumns) ColumnNames() []string {
 	return columns.names
 }
 
-func (columns bigQueryColumns) columnTypes() []bigquery.FieldType {
+func (columns bigQueryColumns) columnTypes() []string {
 	return columns.types
 }
 
@@ -86,7 +86,7 @@ func (column bigQueryColumn) ConvertValue(value bigquery.Value) (driver.Value, e
 func createBigQuerySchema(schema bigquery.Schema, schemaAdaptor adaptor.SchemaAdaptor) bigQuerySchema {
 	var names []string
 	var columns []bigQueryColumn
-	var types []bigquery.FieldType
+	var types []string
 	var requiredFlags []bool
 	for _, column := range schema {
 
@@ -104,9 +104,12 @@ func createBigQuerySchema(schema bigquery.Schema, schemaAdaptor adaptor.SchemaAd
 			Adaptor: columnAdaptor,
 		})
 		if column.Repeated {
-			types = append(types, "ARRAY")
+			// For repeated fields (arrays), use Go slice notation like []STRING.
+			// BigQuery's TYPEOF operator returns `ARRAY<STRING>` for repeated STRING columns,
+			// but we format it as `[]STRING` to match Go conventions and simplify parsing.
+			types = append(types, "[]"+string(column.Type))
 		} else {
-			types = append(types, column.Type)
+			types = append(types, string(column.Type))
 		}
 		requiredFlags = append(requiredFlags, column.Required)
 	}

--- a/driver/rows.go
+++ b/driver/rows.go
@@ -90,7 +90,7 @@ var _ driver.RowsColumnTypeDatabaseTypeName = (*bigQueryRows)(nil)
 
 func (rows *bigQueryRows) ColumnTypeDatabaseTypeName(index int) string {
 	types := rows.schema.columnTypes()
-	return string(types[index])
+	return types[index]
 }
 
 var _ driver.RowsColumnTypeNullable = (*bigQueryRows)(nil)


### PR DESCRIPTION
Fix ColumnTypeDatabaseTypeName to return `[]TYPE` format (e.g., `[]STRING` for string arrays) for BigQuery array types by properly handling the [`Repeated` field](https://github.com/googleapis/google-cloud-go/blob/bigquery/v1.69.0/bigquery/schema.go#L75-L76) in `createBigQuerySchema`.