### PR TITLE
Use BigQuery `ARRAY<TYPE>` notation instead of Go slice notation

### DIFF
--- a/driver/column_type_test.go
+++ b/driver/column_type_test.go
@@ -27,7 +27,7 @@ func TestColumnTypeDatabaseTypeName(t *testing.T) {
 		0: "STRING",
 		1: "NUMERIC",
 		2: "BOOLEAN",
-		3: "[]STRING",
+		3: "ARRAY<STRING>",
 	}
 
 	for index, want := range testCases {

--- a/driver/columns.go
+++ b/driver/columns.go
@@ -104,10 +104,8 @@ func createBigQuerySchema(schema bigquery.Schema, schemaAdaptor adaptor.SchemaAd
 			Adaptor: columnAdaptor,
 		})
 		if column.Repeated {
-			// For repeated fields (arrays), use Go slice notation like []STRING.
-			// BigQuery's TYPEOF operator returns `ARRAY<STRING>` for repeated STRING columns,
-			// but we format it as `[]STRING` to match Go conventions and simplify parsing.
-			types = append(types, "[]"+string(column.Type))
+			// For repeated fields (arrays), use BigQuery ARRAY type notation (e.g., ARRAY<STRING>).
+			types = append(types, "ARRAY<"+string(column.Type)+">")
 		} else {
 			types = append(types, string(column.Type))
 		}


### PR DESCRIPTION
## Summary
• Updates array type representation from `[]STRING` to `ARRAY<STRING>` format
• Makes the format more consistent with BigQuery's native ARRAY type syntax
• Aligns with BigQuery's TYPEOF operator output format

## Test plan
• Existing tests updated to verify the new ARRAY<> format
• Test case for repeated STRING field now expects `ARRAY<STRING>` instead of `[]STRING`

🤖 Generated with [Claude Code](https://claude.ai/code)