### PR TITLE
use user-friendly text for unsupported type value

### DIFF
--- a/driver/rows.go
+++ b/driver/rows.go
@@ -78,7 +78,7 @@ func convertBaseMachinaUnsupportedValueToString(value driver.Value) (string, boo
 		return value.String(), true
 	// ARRAY or STRUCT type
 	case []bigquery.Value:
-		return "<ARRAY or STRUCT>", true
+		return "（未対応の型の値）", true
 	// RANGE type
 	case *bigquery.RangeValue:
 		return fmt.Sprintf("%v,%v", value.Start, value.End), true

--- a/driver/rows_test.go
+++ b/driver/rows_test.go
@@ -37,7 +37,7 @@ func TestConvertBaseMachinaUnsupportedValueToString(t *testing.T) {
 		},
 		"bigquery.Value slice": {
 			value:      []bigquery.Value{"a", "b"},
-			wantString: "<ARRAY or STRUCT>",
+			wantString: "（未対応の型の値）",
 			wantBool:   true,
 		},
 		"bigquery.RangeValue": {


### PR DESCRIPTION
This pull request makes it clearer that `[]bigquery.Value` values are not supported. This `（未対応の型の値）` string will appear directly in the user's screen.